### PR TITLE
#22 - serve match id lists from a saved per-account index

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,8 +3,9 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"build": "tsc -p tsconfig.build.json && node --eval \"require('node:fs').cpSync('src/core/database/migrations', 'dist/core/database/migrations', { recursive: true })\"",
-		"dev": "pnpm run --parallel \"/^dev:/\"",
+		"build": "tsc -p tsconfig.build.json && pnpm run migrations:copy",
+		"migrations:copy": "node --eval \"require('node:fs').cpSync('src/core/database/migrations', 'dist/core/database/migrations', { recursive: true })\"",
+		"dev": "pnpm run migrations:copy && pnpm run --parallel \"/^dev:/\"",
 		"dev:build": "tsc -w -p tsconfig.build.json --preserveWatchOutput",
 		"dev:serve": "node --watch dist/main.js",
 		"start": "node dist/main.js",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { LoggerModule } from "nestjs-pino";
 
 import { DatabaseModule } from "./core/database/database.module.ts";
 import { logger } from "./core/logging/logger.ts";
+import { AccountMatchModule } from "./features/account-matches/account-match.module.ts";
 import { AccountModule } from "./features/accounts/account.module.ts";
 import { MatchModule } from "./features/matches/match.module.ts";
 
@@ -21,6 +22,7 @@ import { MatchModule } from "./features/matches/match.module.ts";
 		}),
 		DatabaseModule,
 		AccountModule,
+		AccountMatchModule,
 		MatchModule,
 	],
 })

--- a/backend/src/core/database/drizzle.ts
+++ b/backend/src/core/database/drizzle.ts
@@ -1,6 +1,8 @@
 import { drizzle } from "drizzle-orm/node-postgres";
 import type { Pool } from "pg";
 
+import { accountMatchSync } from "./models/account-match-sync.model.ts";
+import { accountMatches } from "./models/account-matches.model.ts";
 import { accounts } from "./models/accounts.model.ts";
 import { gameMaps } from "./models/game-maps.model.ts";
 import { gameModes } from "./models/game-modes.model.ts";
@@ -23,6 +25,8 @@ import { perks } from "./models/perks.model.ts";
  * must be added here too.
  */
 const schema = {
+	accountMatchSync,
+	accountMatches,
 	accounts,
 	gameMaps,
 	gameModes,

--- a/backend/src/core/database/migrations/0002_create_account_matches.sql
+++ b/backend/src/core/database/migrations/0002_create_account_matches.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "account_match_sync" (
+	"account_id" integer PRIMARY KEY NOT NULL,
+	"head_synced_at" bigint DEFAULT 0 NOT NULL,
+	"oldest_game_id" bigint,
+	"synced_count" integer DEFAULT 0 NOT NULL,
+	"backfill_complete" boolean DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "account_matches" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"account_id" integer NOT NULL,
+	"match_id" text NOT NULL,
+	"game_id" bigint NOT NULL,
+	"platform_id" text NOT NULL,
+	"date_created" bigint NOT NULL,
+	CONSTRAINT "account_matches_by_match" UNIQUE("account_id","match_id")
+);
+--> statement-breakpoint
+ALTER TABLE "account_match_sync" ADD CONSTRAINT "account_match_sync_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "account_matches" ADD CONSTRAINT "account_matches_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "account_matches_by_recency" ON "account_matches" USING btree ("account_id","game_id" DESC);

--- a/backend/src/core/database/migrations/meta/0002_snapshot.json
+++ b/backend/src/core/database/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1063 @@
+{
+	"id": "13ca87e2-72fc-43ee-a82c-ea343ded6e1a",
+	"prevId": "638d555d-f858-4ce8-8bd4-511b2fc9c83b",
+	"version": "7",
+	"dialect": "postgresql",
+	"tables": {
+		"public.account_match_sync": {
+			"name": "account_match_sync",
+			"schema": "",
+			"columns": {
+				"account_id": {
+					"name": "account_id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"head_synced_at": {
+					"name": "head_synced_at",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"oldest_game_id": {
+					"name": "oldest_game_id",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"synced_count": {
+					"name": "synced_count",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"default": 0
+				},
+				"backfill_complete": {
+					"name": "backfill_complete",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": true,
+					"default": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_match_sync_account_id_accounts_id_fk": {
+					"name": "account_match_sync_account_id_accounts_id_fk",
+					"tableFrom": "account_match_sync",
+					"tableTo": "accounts",
+					"columnsFrom": ["account_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.account_matches": {
+			"name": "account_matches",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"account_id": {
+					"name": "account_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"match_id": {
+					"name": "match_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"game_id": {
+					"name": "game_id",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"platform_id": {
+					"name": "platform_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date_created": {
+					"name": "date_created",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"account_matches_by_recency": {
+					"name": "account_matches_by_recency",
+					"columns": [
+						{
+							"expression": "account_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"game_id\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"account_matches_account_id_accounts_id_fk": {
+					"name": "account_matches_account_id_accounts_id_fk",
+					"tableFrom": "account_matches",
+					"tableTo": "accounts",
+					"columnsFrom": ["account_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"account_matches_by_match": {
+					"name": "account_matches_by_match",
+					"nullsNotDistinct": false,
+					"columns": ["account_id", "match_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.accounts": {
+			"name": "accounts",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"puuid": {
+					"name": "puuid",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"game_name": {
+					"name": "game_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tag_line": {
+					"name": "tag_line",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"game_name_key": {
+					"name": "game_name_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"tag_line_key": {
+					"name": "tag_line_key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"region": {
+					"name": "region",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"riot_id_checked_at": {
+					"name": "riot_id_checked_at",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date_created": {
+					"name": "date_created",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date_updated": {
+					"name": "date_updated",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"accounts_by_riot_id": {
+					"name": "accounts_by_riot_id",
+					"columns": [
+						{
+							"expression": "game_name_key",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "tag_line_key",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "\"riot_id_checked_at\" DESC",
+							"asc": true,
+							"isExpression": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"accounts_puuid_unique": {
+					"name": "accounts_puuid_unique",
+					"nullsNotDistinct": false,
+					"columns": ["puuid"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.game_maps": {
+			"name": "game_maps",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"date_created": {
+					"name": "date_created",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.game_modes": {
+			"name": "game_modes",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"mode": {
+					"name": "mode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date_created": {
+					"name": "date_created",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"game_modes_mode_unique": {
+					"name": "game_modes_mode_unique",
+					"nullsNotDistinct": false,
+					"columns": ["mode"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.game_platforms": {
+			"name": "game_platforms",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"date_created": {
+					"name": "date_created",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.game_queues": {
+			"name": "game_queues",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"date_created": {
+					"name": "date_created",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.game_types": {
+			"name": "game_types",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date_created": {
+					"name": "date_created",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"game_types_type_unique": {
+					"name": "game_types_type_unique",
+					"nullsNotDistinct": false,
+					"columns": ["type"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.match_participant_perks": {
+			"name": "match_participant_perks",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"match_participant_id": {
+					"name": "match_participant_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"kind": {
+					"name": "kind",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"slot": {
+					"name": "slot",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"style_id": {
+					"name": "style_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"perk_id": {
+					"name": "perk_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"match_participant_perks_by_slot": {
+					"name": "match_participant_perks_by_slot",
+					"columns": [
+						{
+							"expression": "match_participant_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "kind",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "slot",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"match_participant_perks_match_participant_id_match_participants_id_fk": {
+					"name": "match_participant_perks_match_participant_id_match_participants_id_fk",
+					"tableFrom": "match_participant_perks",
+					"tableTo": "match_participants",
+					"columnsFrom": ["match_participant_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"match_participant_perks_style_id_perks_id_fk": {
+					"name": "match_participant_perks_style_id_perks_id_fk",
+					"tableFrom": "match_participant_perks",
+					"tableTo": "perks",
+					"columnsFrom": ["style_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"match_participant_perks_perk_id_perks_id_fk": {
+					"name": "match_participant_perks_perk_id_perks_id_fk",
+					"tableFrom": "match_participant_perks",
+					"tableTo": "perks",
+					"columnsFrom": ["perk_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.match_participants": {
+			"name": "match_participants",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"match_row_id": {
+					"name": "match_row_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"participant_index": {
+					"name": "participant_index",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"puuid": {
+					"name": "puuid",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"riot_id_game_name": {
+					"name": "riot_id_game_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"riot_id_tagline": {
+					"name": "riot_id_tagline",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"team_id": {
+					"name": "team_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"team_position": {
+					"name": "team_position",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"champion_id": {
+					"name": "champion_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"champion_name": {
+					"name": "champion_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"win": {
+					"name": "win",
+					"type": "boolean",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"kills": {
+					"name": "kills",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"deaths": {
+					"name": "deaths",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"assists": {
+					"name": "assists",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"gold_earned": {
+					"name": "gold_earned",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"total_minions_killed": {
+					"name": "total_minions_killed",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"neutral_minions_killed": {
+					"name": "neutral_minions_killed",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"summoner1_id": {
+					"name": "summoner1_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"summoner2_id": {
+					"name": "summoner2_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"item0": {
+					"name": "item0",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"item1": {
+					"name": "item1",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"item2": {
+					"name": "item2",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"item3": {
+					"name": "item3",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"item4": {
+					"name": "item4",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"item5": {
+					"name": "item5",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"item6": {
+					"name": "item6",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"placement": {
+					"name": "placement",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				}
+			},
+			"indexes": {
+				"match_participants_by_index": {
+					"name": "match_participants_by_index",
+					"columns": [
+						{
+							"expression": "match_row_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "participant_index",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				},
+				"match_participants_by_puuid": {
+					"name": "match_participants_by_puuid",
+					"columns": [
+						{
+							"expression": "puuid",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "match_row_id",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": false,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {
+				"match_participants_match_row_id_matches_id_fk": {
+					"name": "match_participants_match_row_id_matches_id_fk",
+					"tableFrom": "match_participants",
+					"tableTo": "matches",
+					"columnsFrom": ["match_row_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.matches": {
+			"name": "matches",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"platform_id": {
+					"name": "platform_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"game_id": {
+					"name": "game_id",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"match_id": {
+					"name": "match_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"generated": {
+						"as": "\"matches\".\"platform_id\" || '_' || \"matches\".\"game_id\"",
+						"type": "stored"
+					}
+				},
+				"data_version": {
+					"name": "data_version",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"queue_id": {
+					"name": "queue_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"map_id": {
+					"name": "map_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"game_mode_id": {
+					"name": "game_mode_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"game_type_id": {
+					"name": "game_type_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"patch_id": {
+					"name": "patch_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"game_creation": {
+					"name": "game_creation",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"game_start_ms": {
+					"name": "game_start_ms",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"game_end_ms": {
+					"name": "game_end_ms",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"game_duration": {
+					"name": "game_duration",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"end_of_game_result": {
+					"name": "end_of_game_result",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"payload": {
+					"name": "payload",
+					"type": "bytea",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload_encoding": {
+					"name": "payload_encoding",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"payload_bytes": {
+					"name": "payload_bytes",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"projection_version": {
+					"name": "projection_version",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"fetched_at": {
+					"name": "fetched_at",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"matches_platform_id_game_platforms_id_fk": {
+					"name": "matches_platform_id_game_platforms_id_fk",
+					"tableFrom": "matches",
+					"tableTo": "game_platforms",
+					"columnsFrom": ["platform_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"matches_queue_id_game_queues_id_fk": {
+					"name": "matches_queue_id_game_queues_id_fk",
+					"tableFrom": "matches",
+					"tableTo": "game_queues",
+					"columnsFrom": ["queue_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"matches_map_id_game_maps_id_fk": {
+					"name": "matches_map_id_game_maps_id_fk",
+					"tableFrom": "matches",
+					"tableTo": "game_maps",
+					"columnsFrom": ["map_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"matches_game_mode_id_game_modes_id_fk": {
+					"name": "matches_game_mode_id_game_modes_id_fk",
+					"tableFrom": "matches",
+					"tableTo": "game_modes",
+					"columnsFrom": ["game_mode_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"matches_game_type_id_game_types_id_fk": {
+					"name": "matches_game_type_id_game_types_id_fk",
+					"tableFrom": "matches",
+					"tableTo": "game_types",
+					"columnsFrom": ["game_type_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				},
+				"matches_patch_id_patches_id_fk": {
+					"name": "matches_patch_id_patches_id_fk",
+					"tableFrom": "matches",
+					"tableTo": "patches",
+					"columnsFrom": ["patch_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {
+				"matches_match_id_unique": {
+					"name": "matches_match_id_unique",
+					"nullsNotDistinct": false,
+					"columns": ["match_id"]
+				}
+			},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.patches": {
+			"name": "patches",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"major": {
+					"name": "major",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"minor": {
+					"name": "minor",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true
+				},
+				"date_created": {
+					"name": "date_created",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {
+				"patches_by_version": {
+					"name": "patches_by_version",
+					"columns": [
+						{
+							"expression": "major",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						},
+						{
+							"expression": "minor",
+							"isExpression": false,
+							"asc": true,
+							"nulls": "last"
+						}
+					],
+					"isUnique": true,
+					"concurrently": false,
+					"method": "btree",
+					"with": {}
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		},
+		"public.perks": {
+			"name": "perks",
+			"schema": "",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "integer",
+					"primaryKey": true,
+					"notNull": true
+				},
+				"key": {
+					"name": "key",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"icon": {
+					"name": "icon",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"style_id": {
+					"name": "style_id",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"slot": {
+					"name": "slot",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false
+				},
+				"date_created": {
+					"name": "date_created",
+					"type": "bigint",
+					"primaryKey": false,
+					"notNull": true
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"policies": {},
+			"checkConstraints": {},
+			"isRLSEnabled": false
+		}
+	},
+	"enums": {},
+	"schemas": {},
+	"sequences": {},
+	"roles": {},
+	"policies": {},
+	"views": {},
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	}
+}

--- a/backend/src/core/database/migrations/meta/_journal.json
+++ b/backend/src/core/database/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
 			"when": 1787185674972,
 			"tag": "0001_create_matches",
 			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1787188858906,
+			"tag": "0002_create_account_matches",
+			"breakpoints": true
 		}
 	]
 }

--- a/backend/src/core/database/models/account-match-sync.model.ts
+++ b/backend/src/core/database/models/account-match-sync.model.ts
@@ -1,0 +1,50 @@
+import { bigint, boolean, integer, pgTable } from "drizzle-orm/pg-core";
+
+import { accounts } from "./accounts.model.ts";
+
+/**
+ * How far one account's entry in `account_matches` has been synced, one row per
+ * account.
+ *
+ * Separate from `accounts` because it is bookkeeping for this feature, not part
+ * of what an account is, and because it is written on a completely different
+ * cadence — every id-list read touches it, while an account row is refreshed
+ * once a day.
+ *
+ * The DDL is generated from this file by `pnpm --filter backend db:generate`.
+ */
+export const accountMatchSync = pgTable("account_match_sync", {
+	/**
+	 * Also the primary key: the row *is* the account's sync state, so there is
+	 * nothing to have a second one of.
+	 */
+	accountId: integer("account_id")
+		.primaryKey()
+		.references(() => accounts.id),
+	/**
+	 * Epoch ms the newest end of Riot's list was last read. 0 on a row that has
+	 * never synced, which is what makes the TTL check fire on the first request
+	 * without a null branch beside it.
+	 */
+	headSyncedAt: bigint("head_synced_at", { mode: "number" })
+		.notNull()
+		.default(0),
+	/**
+	 * The lowest `game_id` held for this account, or null while it holds none.
+	 * Recomputed from `account_matches` rather than tracked, so it cannot drift.
+	 */
+	oldestGameId: bigint("oldest_game_id", { mode: "number" }),
+	/**
+	 * How many ids are held, which doubles as the offset the next backfill page
+	 * starts from — Riot's `start` is a position in the same list. Recomputed
+	 * from `account_matches` for that reason: an offset that has drifted from the
+	 * row count would silently skip games.
+	 */
+	syncedCount: integer("synced_count").notNull().default(0),
+	/**
+	 * Set once Riot returns fewer ids than a backfill page asked for, meaning the
+	 * oldest end of the list has been reached. It stops every later Riot call for
+	 * a window the index cannot fill, since there is nothing left to fill it with.
+	 */
+	backfillComplete: boolean("backfill_complete").notNull().default(false),
+});

--- a/backend/src/core/database/models/account-matches.model.ts
+++ b/backend/src/core/database/models/account-matches.model.ts
@@ -1,0 +1,86 @@
+import { sql } from "drizzle-orm";
+import {
+	bigint,
+	index,
+	integer,
+	pgTable,
+	serial,
+	text,
+	unique,
+} from "drizzle-orm/pg-core";
+
+import { accounts } from "./accounts.model.ts";
+
+/**
+ * One match id Riot's match list returned for one account: the cached copy of
+ * `matches/by-puuid/{puuid}/ids`, which is what makes paging a player's history
+ * a database read instead of an offset window over a list that grows at the
+ * head.
+ *
+ * A row means Riot's id list *for this account's puuid* returned that id, and
+ * nothing else.
+ *
+ * Which is why this is not `match_participants` under another name, even though
+ * that table already pairs a puuid with a match. A row lands there whenever
+ * *someone* fetches a match, so the nine other players in it pick up rows for a
+ * history nobody asked to sync — and nothing distinguishes "all of this
+ * player's games" from "the few that overlapped another player's browsing".
+ * Completeness is the only property the paging needs, and it is the one
+ * property a derived set cannot have.
+ *
+ * `account_match_sync.synced_count` is what makes that fatal rather than
+ * untidy: it is used as `start` against Riot's own list, so it has to equal the
+ * length of the prefix of that list actually read. Counting inferred rows
+ * instead points the next backfill at an arbitrary offset, and every id between
+ * there and the real position is skipped — silently, and permanently, since
+ * nothing later goes looking for ids it does not know are missing.
+ *
+ * The other half is cost. This table holds ids whose payloads have not been
+ * fetched, which is what makes paging deep into a history one id-list call;
+ * deriving the list from ingested payloads would mean fetching a full match for
+ * every id on the page just to know the id exists.
+ *
+ * The DDL is generated from this file by `pnpm --filter backend db:generate`.
+ */
+export const accountMatches = pgTable(
+	"account_matches",
+	{
+		id: serial("id").primaryKey(),
+		accountId: integer("account_id")
+			.notNull()
+			.references(() => accounts.id),
+		/**
+		 * Riot's match id, e.g. "NA1_5451234567".
+		 *
+		 * Deliberately not a foreign key to `matches`: the index is populated from
+		 * the id list, which knows an id long before — and often without ever —
+		 * fetching its payload. Requiring a `matches` row would force a full fetch
+		 * of a player's history just to page it.
+		 */
+		matchId: text("match_id").notNull(),
+		/**
+		 * The id's game component, split out so it can be ordered on.
+		 *
+		 * It is monotonic per platform, so it sorts by recency correctly before a
+		 * single payload has been fetched — `game_creation` would need one.
+		 */
+		gameId: bigint("game_id", { mode: "number" }).notNull(),
+		/**
+		 * The id's platform component, e.g. "NA1". Not a foreign key to
+		 * `game_platforms` for the same reason `match_id` is not one to `matches`.
+		 */
+		platformId: text("platform_id").notNull(),
+		/** Epoch ms this id first appeared in a fetched page. */
+		dateCreated: bigint("date_created", { mode: "number" }).notNull(),
+	},
+	(table) => [
+		// The whole sync strategy leans on this: pages are re-fetched with a
+		// deliberate overlap and written blind, so duplicates have to be free.
+		unique("account_matches_by_match").on(table.accountId, table.matchId),
+		// Every read is one account's ids newest first, by cursor or by offset.
+		index("account_matches_by_recency").on(
+			table.accountId,
+			sql`${table.gameId} DESC`,
+		),
+	],
+);

--- a/backend/src/core/database/types/account-match-row.type.ts
+++ b/backend/src/core/database/types/account-match-row.type.ts
@@ -1,0 +1,4 @@
+import type { accountMatches } from "./../models/account-matches.model.ts";
+
+/** A row of `account_matches`, inferred from the model rather than restated. */
+export type AccountMatchRow = typeof accountMatches.$inferSelect;

--- a/backend/src/core/database/types/account-match-sync-row.type.ts
+++ b/backend/src/core/database/types/account-match-sync-row.type.ts
@@ -1,0 +1,4 @@
+import type { accountMatchSync } from "./../models/account-match-sync.model.ts";
+
+/** A row of `account_match_sync`, inferred from the model rather than restated. */
+export type AccountMatchSyncRow = typeof accountMatchSync.$inferSelect;

--- a/backend/src/core/http/http-client.service.test.ts
+++ b/backend/src/core/http/http-client.service.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRetryAfter } from "./http-client.service.ts";
+
+describe("parseRetryAfter", () => {
+	it("reads a delay in seconds", () => {
+		expect(parseRetryAfter("30")).toBe(30);
+	});
+
+	it("rounds a fractional delay up, so the caller never returns early", () => {
+		expect(parseRetryAfter("1.2")).toBe(2);
+	});
+
+	it("treats zero as a real answer rather than a missing one", () => {
+		// Distinct from null: the upstream said the limit is already clear, which
+		// is not the same as it saying nothing.
+		expect(parseRetryAfter("0")).toBe(0);
+	});
+
+	it("gives up on the HTTP-date form rather than trusting a clock", () => {
+		expect(parseRetryAfter("Wed, 21 Oct 2026 07:28:00 GMT")).toBeNull();
+	});
+
+	it("gives up on an absent or unusable header", () => {
+		expect(parseRetryAfter(undefined)).toBeNull();
+		expect(parseRetryAfter("")).toBeNull();
+		expect(parseRetryAfter("-5")).toBeNull();
+		// A repeated header arrives as an array, which is not a delay.
+		expect(parseRetryAfter(["1", "2"])).toBeNull();
+	});
+});

--- a/backend/src/core/http/http-client.service.ts
+++ b/backend/src/core/http/http-client.service.ts
@@ -36,6 +36,28 @@ const describeBody = (body: unknown) => {
 };
 
 /**
+ * Reads a `Retry-After` header as whole seconds, or null if there is nothing
+ * usable in it.
+ *
+ * The header is allowed to be either a delay in seconds or an HTTP date. Only
+ * the numeric form is honoured: Riot sends that one, and a date would have to be
+ * trusted against a clock this process does not share. Anything else — absent,
+ * a date, a negative — comes back null, which the caller reads as "back off on
+ * your own schedule" rather than "come back immediately".
+ */
+export const parseRetryAfter = (header: unknown) => {
+	if (typeof header !== "string" || header.trim() === "") return null;
+
+	// The emptiness check above is not redundant: `Number("")` is 0, so a header
+	// present but blank would otherwise read as "retry immediately" — the one
+	// answer guaranteed to earn a second rate limit.
+	const seconds = Number(header);
+	if (!Number.isFinite(seconds) || seconds < 0) return null;
+
+	return Math.ceil(seconds);
+};
+
+/**
  * The one client every outbound HTTP call goes through.
  *
  * Its job is to make an upstream failure look like a normal Nest error at the
@@ -68,7 +90,23 @@ export class HttpClientService {
 
 				// The upstream body is deliberately not passed on: it can carry API
 				// keys' rate limit headers and the provider's own error text.
-				throw new HttpException("Upstream request failed", status);
+				//
+				// `Retry-After` is the one exception, and only on a 429. A caller that
+				// is told to back off but not for how long can only guess, and a guess
+				// that is short becomes a second rate limit; unlike the
+				// `X-…-Rate-Limit` family it says nothing about the key's tier, only
+				// when this caller may come back.
+				const retryAfter =
+					status === 429
+						? parseRetryAfter(error.response?.headers["retry-after"])
+						: null;
+
+				throw new HttpException(
+					retryAfter === null
+						? "Upstream request failed"
+						: { message: "Upstream request failed", retryAfter },
+					status,
+				);
 			},
 		);
 	}

--- a/backend/src/features/account-matches/account-match-merge.utils.test.ts
+++ b/backend/src/features/account-matches/account-match-merge.utils.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	mergeBackfillPage,
+	mergeHeadPage,
+} from "./account-match-merge.utils.ts";
+
+const PAGE_SIZE = 20;
+
+/** A page of `count` ids, counting down from `from` the way Riot orders them. */
+const page = (from: number, count: number) =>
+	Array.from({ length: count }, (_, offset) => `NA1_${from - offset}`);
+
+describe("mergeHeadPage", () => {
+	it("takes only the ids the index does not hold", () => {
+		const merge = mergeHeadPage(new Set(["NA1_3", "NA1_2"]), page(4, 4), {
+			pageSize: PAGE_SIZE,
+			syncedCount: 2,
+		});
+
+		expect(merge.fresh).toEqual(["NA1_4", "NA1_1"]);
+	});
+
+	it("stops at the first known id, which is the join with the cached set", () => {
+		const fetched = [...page(100, 2), ...page(80, 18)];
+
+		const merge = mergeHeadPage(new Set(["NA1_80"]), fetched, {
+			pageSize: PAGE_SIZE,
+			syncedCount: 40,
+		});
+
+		expect(merge.keepPaging).toBe(false);
+	});
+
+	it("keeps paging on a page of nothing but new ids", () => {
+		// More games were played than the window covers, so nothing here proves
+		// the page joins the cached set — a gap may sit just past it.
+		const merge = mergeHeadPage(new Set(), page(100, PAGE_SIZE), {
+			pageSize: PAGE_SIZE,
+			syncedCount: 40,
+		});
+
+		expect(merge.fresh).toHaveLength(PAGE_SIZE);
+		expect(merge.keepPaging).toBe(true);
+	});
+
+	it("stops on a short page, which is the end of Riot's list", () => {
+		const merge = mergeHeadPage(new Set(), page(100, 7), {
+			pageSize: PAGE_SIZE,
+			syncedCount: 40,
+		});
+
+		expect(merge.keepPaging).toBe(false);
+	});
+
+	it("takes one page when the index is empty and leaves the rest to backfill", () => {
+		// Every page would be all-new, so the rule above would walk the entire
+		// history inside a head refresh.
+		const merge = mergeHeadPage(new Set(), page(100, PAGE_SIZE), {
+			pageSize: PAGE_SIZE,
+			syncedCount: 0,
+		});
+
+		expect(merge.fresh).toHaveLength(PAGE_SIZE);
+		expect(merge.keepPaging).toBe(false);
+	});
+});
+
+describe("mergeBackfillPage", () => {
+	it("accepts a page whose overlap with the index materialised", () => {
+		const fetched = page(50, 10);
+
+		const merge = mergeBackfillPage(new Set(fetched.slice(0, 5)), fetched, {
+			startOffset: 40,
+			requested: 10,
+		});
+
+		expect(merge.overlapSeen).toBe(true);
+		expect(merge.fresh).toEqual(fetched.slice(5));
+	});
+
+	it("refuses a page whose first id is unknown, since a gap would open", () => {
+		// Games played since the last sync shifted every offset right by more than
+		// the overlap covers, so the ids between this page and the index would
+		// never be fetched.
+		const merge = mergeBackfillPage(new Set(["NA1_20"]), page(50, 10), {
+			startOffset: 40,
+			requested: 10,
+		});
+
+		expect(merge.overlapSeen).toBe(false);
+	});
+
+	it("needs no overlap at offset 0, where nothing precedes the page", () => {
+		const merge = mergeBackfillPage(new Set(), page(50, 10), {
+			startOffset: 0,
+			requested: 10,
+		});
+
+		expect(merge.overlapSeen).toBe(true);
+	});
+
+	it("reports the tail when Riot returns fewer ids than asked for", () => {
+		const fetched = page(50, 3);
+
+		const merge = mergeBackfillPage(new Set([fetched[0]]), fetched, {
+			startOffset: 40,
+			requested: 10,
+		});
+
+		expect(merge.complete).toBe(true);
+	});
+
+	it("does not report the tail on a full page", () => {
+		const fetched = page(50, 10);
+
+		const merge = mergeBackfillPage(new Set([fetched[0]]), fetched, {
+			startOffset: 40,
+			requested: 10,
+		});
+
+		expect(merge.complete).toBe(false);
+	});
+
+	it("treats an empty page as the tail rather than a missing overlap", () => {
+		const merge = mergeBackfillPage(new Set(), [], {
+			startOffset: 40,
+			requested: 10,
+		});
+
+		expect(merge.overlapSeen).toBe(true);
+		expect(merge.complete).toBe(true);
+	});
+});

--- a/backend/src/features/account-matches/account-match-merge.utils.ts
+++ b/backend/src/features/account-matches/account-match-merge.utils.ts
@@ -1,0 +1,93 @@
+/**
+ * The decisions a fetched page of match ids leads to, taken as pure functions of
+ * the page and what the index already holds.
+ *
+ * They are separated from the repository and the Riot client because they are
+ * the only part of the sync that can be wrong in a way nothing later notices: a
+ * duplicate id is absorbed by `account_matches`' unique constraint, but a gap
+ * between what was fetched and what was held is silent and permanent. Keeping
+ * the rules pure is what makes the gap cases directly testable.
+ */
+
+/** What a page of the newest end of Riot's list leaves to do. */
+export interface IHeadPageMerge {
+	/** Ids in the page the index does not hold yet, in Riot's order. */
+	fresh: string[];
+	/**
+	 * Whether the next page has to be fetched before the head can be called
+	 * synced.
+	 */
+	keepPaging: boolean;
+}
+
+/**
+ * Merges a page of the newest end of Riot's list into the index.
+ *
+ * `known` only has to cover `page` — it is the answer to "which of these ids do
+ * we already hold", not the whole index, so a head refresh never loads a full
+ * history into memory to write twenty ids.
+ *
+ * Paging continues only while every id on the page is new. One already-known id
+ * is the join between the page and the cached set, which proves nothing sits
+ * between them; a page of nothing but new ids proves the opposite — more games
+ * were played than the window covers, so a gap may sit just past it.
+ *
+ * Two cases stop it anyway. A short page is the end of Riot's list, so there is
+ * no next page. And an index holding nothing has no cached set to rejoin, so
+ * every page would be all-new and the head refresh would walk the entire
+ * history — that walk is the backfill's job, bounded and resumable, so the head
+ * takes one page and leaves the rest to it.
+ */
+export const mergeHeadPage = (
+	known: ReadonlySet<string>,
+	page: readonly string[],
+	options: { pageSize: number; syncedCount: number },
+): IHeadPageMerge => {
+	const fresh = page.filter((id) => !known.has(id));
+
+	return {
+		fresh,
+		keepPaging:
+			options.syncedCount > 0 &&
+			fresh.length === page.length &&
+			page.length >= options.pageSize,
+	};
+};
+
+/** What a page of the oldest end of Riot's list leaves to do. */
+export interface IBackfillPageMerge {
+	/** Ids in the page the index does not hold yet, in Riot's order. */
+	fresh: string[];
+	/**
+	 * Whether the deliberate overlap with the ids already held actually showed
+	 * up. False means offsets shifted further than the overlap covers and the
+	 * page cannot be written: the ids between it and the index would never be
+	 * fetched.
+	 */
+	overlapSeen: boolean;
+	/** Riot returned fewer ids than asked for, so this is the tail of the list. */
+	complete: boolean;
+}
+
+/**
+ * Merges a page of the oldest end of Riot's list into the index.
+ *
+ * The page is fetched starting a few ids back inside what is already held, so
+ * its first id must be one of them. If it is not, games played since the last
+ * sync shifted every offset right by more than the overlap, and writing the page
+ * would leave a hole between it and the index — so the caller is told to refresh
+ * the head first and try again rather than being handed rows to write.
+ *
+ * At offset 0 there is nothing before the page for it to overlap with, and an
+ * empty page cannot show an overlap it has no room for; neither is a gap.
+ */
+export const mergeBackfillPage = (
+	known: ReadonlySet<string>,
+	page: readonly string[],
+	options: { startOffset: number; requested: number },
+): IBackfillPageMerge => ({
+	fresh: page.filter((id) => !known.has(id)),
+	overlapSeen:
+		options.startOffset === 0 || page.length === 0 || known.has(page[0]),
+	complete: page.length < options.requested,
+});

--- a/backend/src/features/account-matches/account-match-sync.constant.ts
+++ b/backend/src/features/account-matches/account-match-sync.constant.ts
@@ -1,0 +1,29 @@
+/**
+ * How long the newest end of a cached id list is trusted before Riot's list is
+ * read again.
+ *
+ * Short because this is the one part of the index that goes stale: a completed
+ * match never changes, but a game finishing adds an id at the head. A minute is
+ * the resolution at which a just-finished game shows up, and it still collapses
+ * the several id-list calls a page refresh used to make into one.
+ */
+export const ACCOUNT_MATCH_HEAD_TTL_MS = 60 * 1000;
+
+/**
+ * How many ids a sync fetches at once. Riot caps `count` at 100; 20 keeps a
+ * head refresh that has to page cheap, since the common case rejoins the cached
+ * set inside the first page.
+ */
+export const ACCOUNT_MATCH_PAGE_SIZE = 20;
+
+/**
+ * How far back into the ids already held a backfill page starts.
+ *
+ * Games played since the last sync shift every offset in Riot's list to the
+ * right, so a backfill that started exactly at `synced_count` would skip that
+ * many ids. Re-fetching the last few absorbs the shift, and duplicates cost
+ * nothing — the unique constraint absorbs them, while a gap is silent and
+ * permanent. The overlap is also the check: if it does not materialise, the
+ * shift was larger than this and the page is refused.
+ */
+export const ACCOUNT_MATCH_BACKFILL_OVERLAP = 5;

--- a/backend/src/features/account-matches/account-match.controller.ts
+++ b/backend/src/features/account-matches/account-match.controller.ts
@@ -1,0 +1,75 @@
+import {
+	BadRequestException,
+	Controller,
+	Get,
+	Logger,
+	Param,
+	Query,
+} from "@nestjs/common";
+
+import { splitMatchId } from "./../../lib/split-match-id.ts";
+import { AccountMatchService } from "./account-match.service.ts";
+
+/**
+ * Declares the `accounts` prefix although it lives outside the accounts
+ * feature: the ids are a collection belonging to one account, so the URL nests
+ * under it, while the code that serves them is a match index and belongs beside
+ * the tables it maintains. Nest binds routes by decorator, not by directory,
+ * so the two do not have to agree.
+ */
+@Controller("accounts")
+export class AccountMatchController {
+	private readonly logger = new Logger(AccountMatchController.name);
+	private readonly accountMatches: AccountMatchService;
+
+	constructor(accountMatches: AccountMatchService) {
+		this.accountMatches = accountMatches;
+	}
+
+	/**
+	 * `GET /accounts/:puuid/matches?before=&start=&count=` — a page of the
+	 * account's match ids, newest first.
+	 *
+	 * `before` is a match id and the cursor form; it is what a client paging
+	 * through a history should send, because `start` counts from a head that
+	 * moves as games finish. `start` still works, and the response is a plain
+	 * array of ids either way.
+	 */
+	@Get(":puuid/matches")
+	async getMatchIds(
+		@Param("puuid") puuid: string,
+		@Query("start") start?: string,
+		@Query("count") count?: string,
+		@Query("before") before?: string,
+	) {
+		const startIndex = Number(start) || 0;
+		const pageSize = Number(count) || 5;
+
+		const matchIds = await this.accountMatches.getMatchIds(puuid, {
+			beforeGameId: parseCursor(before),
+			start: startIndex,
+			count: pageSize,
+		});
+		this.logger.debug(
+			`Served ${matchIds.length} match ids (before=${before ?? "-"}, start=${startIndex}, count=${pageSize})`,
+		);
+		return matchIds;
+	}
+}
+
+/**
+ * Reads the `before` cursor as the game id to page from.
+ *
+ * The cursor is a match id rather than a bare game id so a client can hand back
+ * the last id it was served without taking it apart. It is only ever split
+ * here — the id itself is never looked up, so a cursor naming a match the index
+ * does not hold still pages from the right position.
+ */
+const parseCursor = (before: string | undefined) => {
+	if (!before) return undefined;
+	try {
+		return splitMatchId(before).gameId;
+	} catch {
+		throw new BadRequestException(`Not a match id: ${before}`);
+	}
+};

--- a/backend/src/features/account-matches/account-match.module.ts
+++ b/backend/src/features/account-matches/account-match.module.ts
@@ -1,0 +1,16 @@
+import { Module } from "@nestjs/common";
+
+import { RiotModule } from "./../../integrations/riot/riot.module.ts";
+import { AccountModule } from "./../accounts/account.module.ts";
+import { AccountMatchController } from "./account-match.controller.ts";
+import { AccountMatchRepository } from "./account-match.repository.ts";
+import { AccountMatchService } from "./account-match.service.ts";
+
+@Module({
+	// AccountModule for its repository: the id index hangs off an account row, so
+	// a puuid has to be resolved to one before anything can be cached against it.
+	imports: [RiotModule, AccountModule],
+	controllers: [AccountMatchController],
+	providers: [AccountMatchService, AccountMatchRepository],
+})
+export class AccountMatchModule {}

--- a/backend/src/features/account-matches/account-match.repository.ts
+++ b/backend/src/features/account-matches/account-match.repository.ts
@@ -1,0 +1,164 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { and, desc, eq, inArray, lt, sql } from "drizzle-orm";
+
+import { DRIZZLE } from "./../../core/database/database.constant.ts";
+import type { Drizzle } from "./../../core/database/drizzle.ts";
+import { accountMatchSync } from "./../../core/database/models/account-match-sync.model.ts";
+import { accountMatches } from "./../../core/database/models/account-matches.model.ts";
+import { splitMatchId } from "./../../lib/split-match-id.ts";
+
+/** Which window of an account's ids to read, newest first. */
+export interface IMatchIdWindow {
+	/**
+	 * Read the ids older than this game id. The cursor form: it names a position
+	 * in the list rather than counting from a head that moves, so a game finishing
+	 * between two pages cannot make the second repeat or skip ids.
+	 */
+	beforeGameId?: number;
+	/** Offset form, kept because the frontend still pages by it. */
+	start: number;
+	count: number;
+}
+
+/** Every read and write against `account_matches` and `account_match_sync`. */
+@Injectable()
+export class AccountMatchRepository {
+	private readonly db: Drizzle;
+
+	constructor(@Inject(DRIZZLE) db: Drizzle) {
+		this.db = db;
+	}
+
+	/**
+	 * The account's sync row, created on first use.
+	 *
+	 * `DO UPDATE` writing the key to itself rather than `DO NOTHING`, because
+	 * `DO NOTHING` returns nothing on a conflict and the row is wanted either way
+	 * — this is one statement for both the first request and every later one.
+	 */
+	async ensureSync(accountId: number) {
+		const [row] = await this.db
+			.insert(accountMatchSync)
+			.values({ accountId })
+			.onConflictDoUpdate({
+				target: accountMatchSync.accountId,
+				set: { accountId: sql`excluded.account_id` },
+			})
+			.returning();
+
+		return row;
+	}
+
+	/**
+	 * Which of `matchIds` the account already holds.
+	 *
+	 * Scoped to the ids asked about rather than returning the whole index: the
+	 * merge functions only ever ask about the page in hand, and a long history
+	 * should not be loaded into memory to write twenty ids.
+	 */
+	async findKnown(accountId: number, matchIds: readonly string[]) {
+		if (matchIds.length === 0) return new Set<string>();
+
+		const rows = await this.db
+			.select({ matchId: accountMatches.matchId })
+			.from(accountMatches)
+			.where(
+				and(
+					eq(accountMatches.accountId, accountId),
+					inArray(accountMatches.matchId, [...matchIds]),
+				),
+			);
+
+		return new Set(rows.map((row) => row.matchId));
+	}
+
+	/**
+	 * Adds ids to the index, ignoring any already there.
+	 *
+	 * Written blind on purpose: every page is fetched with an overlap it is
+	 * expected to re-see, so `DO NOTHING` on the unique constraint is what makes
+	 * over-fetching free. The count returned is how many were new, which is how
+	 * the caller knows a backfill page made progress.
+	 */
+	async insertIds(
+		accountId: number,
+		matchIds: readonly string[],
+		dateCreated: number,
+	) {
+		if (matchIds.length === 0) return 0;
+
+		const rows = await this.db
+			.insert(accountMatches)
+			.values(
+				matchIds.map((matchId) => ({
+					accountId,
+					matchId,
+					...splitMatchId(matchId),
+					dateCreated,
+				})),
+			)
+			.onConflictDoNothing()
+			.returning({ id: accountMatches.id });
+
+		return rows.length;
+	}
+
+	/**
+	 * Recomputes the sync counters from `account_matches`, applying `patch` in the
+	 * same statement.
+	 *
+	 * Derived rather than incremented because `synced_count` is used as an offset
+	 * into Riot's own list: a count that had drifted from the rows actually held
+	 * would start the next backfill in the wrong place and skip whatever sat
+	 * between. Recomputing costs an indexed aggregate and cannot drift.
+	 */
+	async refreshSync(
+		accountId: number,
+		patch: { headSyncedAt?: number; backfillComplete?: boolean } = {},
+	) {
+		// Both aggregates run as subqueries inside the UPDATE, so neither count
+		// travels to Node and back.
+		const held = eq(accountMatches.accountId, accountId);
+
+		const [row] = await this.db
+			.update(accountMatchSync)
+			.set({
+				...patch,
+				syncedCount: sql`(select count(*)::int from ${accountMatches} where ${held})`,
+				oldestGameId: sql`(select min(${accountMatches.gameId}) from ${accountMatches} where ${held})`,
+			})
+			.where(eq(accountMatchSync.accountId, accountId))
+			.returning();
+
+		return row;
+	}
+
+	/**
+	 * A window of the account's ids, newest first.
+	 *
+	 * Ordered by `game_id` rather than by anything off a payload, so an id is
+	 * placed correctly the moment it is indexed. Ids from two platforms would
+	 * interleave by a number only comparable within one, which no account seen so
+	 * far has — a puuid plays on the shard it was made on.
+	 */
+	async listMatchIds(accountId: number, window: IMatchIdWindow) {
+		const rows = await this.db
+			.select({ matchId: accountMatches.matchId })
+			.from(accountMatches)
+			.where(
+				and(
+					eq(accountMatches.accountId, accountId),
+					window.beforeGameId === undefined
+						? undefined
+						: lt(accountMatches.gameId, window.beforeGameId),
+				),
+			)
+			.orderBy(desc(accountMatches.gameId))
+			.limit(window.count)
+			// A cursor already names where to start, so the offset only applies to
+			// the offset form; combining them would page from inside the cursor.
+			.offset(window.beforeGameId === undefined ? window.start : 0);
+
+		return rows.map((row) => row.matchId);
+	}
+}

--- a/backend/src/features/account-matches/account-match.service.test.ts
+++ b/backend/src/features/account-matches/account-match.service.test.ts
@@ -1,0 +1,165 @@
+import { Test } from "@nestjs/testing";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTestDatabase } from "./../../core/database/create-test-database.ts";
+import { DRIZZLE } from "./../../core/database/database.constant.ts";
+import { RiotApiService } from "./../../integrations/riot/riot-api.service.ts";
+import { AccountRepository } from "./../accounts/account.repository.ts";
+import { AccountMatchRepository } from "./account-match.repository.ts";
+import { AccountMatchService } from "./account-match.service.ts";
+import { ACCOUNT_MATCH_HEAD_TTL_MS } from "./account-match-sync.constant.ts";
+
+const PUUID = "puuid-1";
+const NOW = 1_700_000_000_000;
+
+/** Riot's list for the account, newest first — the thing being cached. */
+let history: string[];
+let fetchMatchIds: ReturnType<typeof vi.fn>;
+let service: AccountMatchService;
+let teardown: () => Promise<void>;
+
+/** `count` ids counting down from `from`, in Riot's own newest-first order. */
+const games = (from: number, count: number) =>
+	Array.from({ length: count }, (_, offset) => `NA1_${from - offset}`);
+
+beforeEach(async () => {
+	const database = await createTestDatabase();
+	teardown = database.teardown;
+
+	history = games(1030, 30);
+	// Riot's endpoint, modelled as the window over the list that it is — which is
+	// exactly why an offset is not a stable cursor.
+	fetchMatchIds = vi.fn(async (_puuid: string, start: number, count: number) =>
+		history.slice(start, start + count),
+	);
+
+	const moduleRef = await Test.createTestingModule({
+		providers: [AccountMatchService, AccountMatchRepository, AccountRepository],
+	})
+		.useMocker((token) => {
+			if (token === DRIZZLE) return database.db;
+			if (token === RiotApiService) return { fetchMatchIds };
+		})
+		.compile();
+
+	service = moduleRef.get(AccountMatchService);
+
+	// The index hangs off an account row, so there has to be one to hang it off.
+	await moduleRef.get(AccountRepository).upsert(
+		{
+			puuid: PUUID,
+			gameName: "Sneaky",
+			tagLine: "NA69",
+			region: "americas",
+		},
+		NOW,
+	);
+});
+
+afterEach(() => teardown());
+
+describe("AccountMatchService.getMatchIds", () => {
+	it("serves the window and caches the ids it fetched", async () => {
+		const first = await service.getMatchIds(PUUID, { start: 0, count: 5 }, NOW);
+
+		expect(first).toEqual(games(1030, 5));
+		expect(fetchMatchIds).toHaveBeenCalledTimes(1);
+	});
+
+	it("serves a repeat request inside the TTL without calling Riot", async () => {
+		await service.getMatchIds(PUUID, { start: 0, count: 5 }, NOW);
+
+		const again = await service.getMatchIds(
+			PUUID,
+			{ start: 0, count: 5 },
+			NOW + ACCOUNT_MATCH_HEAD_TTL_MS - 1,
+		);
+
+		expect(again).toEqual(games(1030, 5));
+		expect(fetchMatchIds).toHaveBeenCalledTimes(1);
+	});
+
+	it("reads the head again once the TTL has expired, and picks up new games", async () => {
+		await service.getMatchIds(PUUID, { start: 0, count: 5 }, NOW);
+		history = [...games(1032, 2), ...history];
+
+		const later = await service.getMatchIds(
+			PUUID,
+			{ start: 0, count: 5 },
+			NOW + ACCOUNT_MATCH_HEAD_TTL_MS,
+		);
+
+		expect(later).toEqual(games(1032, 5));
+		expect(fetchMatchIds).toHaveBeenCalledTimes(2);
+	});
+
+	it("backfills until the window is filled", async () => {
+		const deep = await service.getMatchIds(PUUID, { start: 0, count: 25 }, NOW);
+
+		expect(deep).toEqual(games(1030, 25));
+	});
+
+	it("stops calling Riot once the backfill has reached the tail", async () => {
+		// The window asks for more than the account has ever played, so the first
+		// request runs the backfill out and marks it complete.
+		const all = await service.getMatchIds(PUUID, { start: 0, count: 50 }, NOW);
+		expect(all).toHaveLength(30);
+		const callsToReachTheTail = fetchMatchIds.mock.calls.length;
+
+		const again = await service.getMatchIds(
+			PUUID,
+			{ start: 0, count: 50 },
+			NOW + 1,
+		);
+
+		expect(again).toHaveLength(30);
+		// Not "no more calls": the head TTL is a separate clock and this request
+		// is inside it. The point is that nothing goes looking for a tail that has
+		// already been found.
+		expect(fetchMatchIds).toHaveBeenCalledTimes(callsToReachTheTail);
+	});
+
+	it("pages by cursor without repeating or skipping when games finish in between", async () => {
+		// The bug this whole index exists to fix. Two games land between the two
+		// requests, shifting every offset in Riot's list right by two.
+		const first = await service.getMatchIds(
+			PUUID,
+			{ start: 0, count: 10 },
+			NOW,
+		);
+		history = [...games(1032, 2), ...history];
+
+		const second = await service.getMatchIds(
+			PUUID,
+			{ beforeGameId: 1021, start: 0, count: 10 },
+			NOW + ACCOUNT_MATCH_HEAD_TTL_MS,
+		);
+
+		expect(first).toEqual(games(1030, 10));
+		expect(second).toEqual(games(1020, 10));
+		expect(second.filter((id) => first.includes(id))).toEqual([]);
+	});
+
+	it("still shifts when paged by offset, which is why the cursor exists", async () => {
+		const first = await service.getMatchIds(
+			PUUID,
+			{ start: 0, count: 10 },
+			NOW,
+		);
+		history = [...games(1032, 2), ...history];
+
+		const second = await service.getMatchIds(
+			PUUID,
+			{ start: 10, count: 10 },
+			NOW + ACCOUNT_MATCH_HEAD_TTL_MS,
+		);
+
+		// Two ids the client has already seen, and two it now never will —
+		// unchanged from the old behaviour, because an offset into a list that
+		// grows at the head cannot be stable however the list is stored.
+		expect(second.filter((id) => first.includes(id))).toEqual([
+			"NA1_1022",
+			"NA1_1021",
+		]);
+	});
+});

--- a/backend/src/features/account-matches/account-match.service.ts
+++ b/backend/src/features/account-matches/account-match.service.ts
@@ -1,0 +1,206 @@
+import { Injectable, Logger } from "@nestjs/common";
+
+import { RiotApiService } from "./../../integrations/riot/riot-api.service.ts";
+import { AccountRepository } from "./../accounts/account.repository.ts";
+import { AccountMatchRepository } from "./account-match.repository.ts";
+import {
+	mergeBackfillPage,
+	mergeHeadPage,
+} from "./account-match-merge.utils.ts";
+import {
+	ACCOUNT_MATCH_BACKFILL_OVERLAP,
+	ACCOUNT_MATCH_HEAD_TTL_MS,
+	ACCOUNT_MATCH_PAGE_SIZE,
+} from "./account-match-sync.constant.ts";
+
+/** Which window of a player's match ids to serve, newest first. */
+export interface IMatchIdRequest {
+	/**
+	 * Serve the ids older than this match id. Preferred to `start`: an offset
+	 * counts from a head that moves, so two games finishing between page 1 and
+	 * page 2 make the client see two ids twice and never see two others.
+	 */
+	beforeGameId?: number;
+	start: number;
+	count: number;
+}
+
+/**
+ * Serves a player's match ids out of `account_matches`, calling Riot only to
+ * keep that index current.
+ *
+ * The index is the source the route reads. Riot's own id list is read in two
+ * places only: the newest end, on a TTL, because a finished game adds an id
+ * there; and the oldest end, when a caller asks for a window deeper than the
+ * index reaches. Everything else is a database read.
+ */
+@Injectable()
+export class AccountMatchService {
+	private readonly logger = new Logger(AccountMatchService.name);
+	private readonly accounts: AccountRepository;
+	private readonly accountMatches: AccountMatchRepository;
+	private readonly riot: RiotApiService;
+
+	constructor(
+		accounts: AccountRepository,
+		accountMatches: AccountMatchRepository,
+		riot: RiotApiService,
+	) {
+		this.accounts = accounts;
+		this.accountMatches = accountMatches;
+		this.riot = riot;
+	}
+
+	/**
+	 * A window of the player's match ids, newest first.
+	 *
+	 * `now` is a parameter rather than a `Date.now()` call so the head TTL
+	 * boundary is testable without waiting a minute.
+	 */
+	async getMatchIds(
+		puuid: string,
+		request: IMatchIdRequest,
+		now: number = Date.now(),
+	): Promise<string[]> {
+		const account = await this.accounts.findByPuuid(puuid);
+		if (!account) {
+			// The index hangs off an account row, and one cannot be written from a
+			// puuid alone — the name columns are `NOT NULL` and only account-v1
+			// knows them. Every caller resolves the account before asking for its
+			// matches, so this is a defensive passthrough rather than a path the
+			// app takes; it is served uncached, with the offset paging bug intact.
+			this.logger.warn(
+				`No account row for ${puuid}; serving match ids straight from Riot`,
+			);
+			return this.riot.fetchMatchIds(puuid, request.start, request.count);
+		}
+
+		await this.syncHead(account.id, puuid, now);
+		return this.readWindow(account.id, puuid, request, now);
+	}
+
+	/**
+	 * Brings the newest end of the index up to date, if the TTL has expired.
+	 *
+	 * Pages forward while every id returned is new, since that means more games
+	 * were played than the window covers and a gap may sit past it. `force`
+	 * ignores the TTL, which is how a backfill that found its offsets shifted
+	 * gets them realigned before trying again.
+	 */
+	private async syncHead(
+		accountId: number,
+		puuid: string,
+		now: number,
+		force = false,
+	) {
+		const sync = await this.accountMatches.ensureSync(accountId);
+		if (!force && now - sync.headSyncedAt < ACCOUNT_MATCH_HEAD_TTL_MS) return;
+
+		let startOffset = 0;
+		for (;;) {
+			const page = await this.riot.fetchMatchIds(
+				puuid,
+				startOffset,
+				ACCOUNT_MATCH_PAGE_SIZE,
+			);
+			const known = await this.accountMatches.findKnown(accountId, page);
+			const merge = mergeHeadPage(known, page, {
+				pageSize: ACCOUNT_MATCH_PAGE_SIZE,
+				syncedCount: sync.syncedCount,
+			});
+
+			await this.accountMatches.insertIds(accountId, merge.fresh, now);
+			if (!merge.keepPaging) break;
+			startOffset += ACCOUNT_MATCH_PAGE_SIZE;
+		}
+
+		await this.accountMatches.refreshSync(accountId, { headSyncedAt: now });
+	}
+
+	/**
+	 * Reads the window, backfilling until it can be filled or there is nothing
+	 * left to fill it with.
+	 *
+	 * Retrying the read rather than computing how deep the window reaches keeps
+	 * the cursor and offset forms on one path: both are short for the same
+	 * reason, and both are satisfied by the same extra page. The loop terminates
+	 * because a backfill reports progress only when it actually added ids, and
+	 * Riot's list is finite.
+	 */
+	private async readWindow(
+		accountId: number,
+		puuid: string,
+		request: IMatchIdRequest,
+		now: number,
+	) {
+		for (;;) {
+			const matchIds = await this.accountMatches.listMatchIds(
+				accountId,
+				request,
+			);
+			if (matchIds.length >= request.count) return matchIds;
+
+			const progressed = await this.backfillOnce(accountId, puuid, now);
+			if (!progressed) return matchIds;
+		}
+	}
+
+	/**
+	 * Fetches one page deeper into Riot's list, and reports whether the index
+	 * grew.
+	 *
+	 * The page starts a few ids back inside what is held so the shift caused by
+	 * games played since the last sync is absorbed. When the overlap does not
+	 * materialise the shift was larger than that, and writing the page would
+	 * leave a hole; the head is resynced to take up the shift and the page is
+	 * retried once. A second failure is left alone rather than guessed at — the
+	 * window comes back short, which is recoverable, while a gap would not be.
+	 */
+	private async backfillOnce(
+		accountId: number,
+		puuid: string,
+		now: number,
+		retried = false,
+	): Promise<boolean> {
+		const sync = await this.accountMatches.ensureSync(accountId);
+		if (sync.backfillComplete) return false;
+
+		const startOffset = Math.max(
+			0,
+			sync.syncedCount - ACCOUNT_MATCH_BACKFILL_OVERLAP,
+		);
+		const page = await this.riot.fetchMatchIds(
+			puuid,
+			startOffset,
+			ACCOUNT_MATCH_PAGE_SIZE,
+		);
+		const known = await this.accountMatches.findKnown(accountId, page);
+		const merge = mergeBackfillPage(known, page, {
+			startOffset,
+			requested: ACCOUNT_MATCH_PAGE_SIZE,
+		});
+
+		if (!merge.overlapSeen) {
+			if (retried) {
+				this.logger.warn(
+					`Backfill for ${puuid} found no overlap at start=${startOffset} after a head resync; leaving the window short rather than writing a gap`,
+				);
+				return false;
+			}
+			await this.syncHead(accountId, puuid, now, true);
+			return this.backfillOnce(accountId, puuid, now, true);
+		}
+
+		const added = await this.accountMatches.insertIds(
+			accountId,
+			merge.fresh,
+			now,
+		);
+		await this.accountMatches.refreshSync(
+			accountId,
+			merge.complete ? { backfillComplete: true } : {},
+		);
+
+		return added > 0;
+	}
+}

--- a/backend/src/features/accounts/account.module.ts
+++ b/backend/src/features/accounts/account.module.ts
@@ -9,6 +9,6 @@ import { AccountService } from "./account.service.ts";
 	imports: [RiotModule],
 	controllers: [AccountController],
 	providers: [AccountService, AccountRepository],
-	exports: [AccountService],
+	exports: [AccountService, AccountRepository],
 })
 export class AccountModule {}

--- a/backend/src/features/accounts/account.repository.ts
+++ b/backend/src/features/accounts/account.repository.ts
@@ -38,6 +38,16 @@ export class AccountRepository {
 	}
 
 	/**
+	 * Looks an account up by puuid, which is unique — unlike the riot id, so this
+	 * one needs no tie-break and can return at most one row.
+	 */
+	async findByPuuid(puuid: string) {
+		return this.db.query.accounts.findFirst({
+			where: eq(accounts.puuid, puuid),
+		});
+	}
+
+	/**
 	 * Inserts or refreshes an account. Conflicts resolve on `puuid`, never on the
 	 * name, so a rename updates the existing row instead of creating a second one.
 	 */

--- a/backend/src/features/matches/match-projection.utils.ts
+++ b/backend/src/features/matches/match-projection.utils.ts
@@ -1,6 +1,7 @@
 import type { matchParticipants } from "./../../core/database/models/match-participants.model.ts";
 import type { matches } from "./../../core/database/models/matches.model.ts";
 import type { PerkKind } from "./../../core/database/types/perk-kind.type.ts";
+import { splitMatchId } from "./../../lib/split-match-id.ts";
 import type { IRiotMatchDto } from "./types/i-riot-match-dto.type.ts";
 
 /**
@@ -54,23 +55,6 @@ type MatchParticipantProjection = Omit<
 	typeof matchParticipants.$inferInsert,
 	"id" | "matchRowId"
 >;
-
-/**
- * Splits a match id into the platform and game id it is built from.
- *
- * The id is `platform_id + "_" + game_id` in every sampled payload, so this is
- * the authoritative source for both — more so than `info.platformId`, which the
- * caller has no way to have asked for. A `matchId` in some other shape is a
- * caller error rather than a Riot one, so this one does throw.
- */
-const splitMatchId = (matchId: string) => {
-	const separator = matchId.indexOf("_");
-	const gameId = Number(matchId.slice(separator + 1));
-	if (separator <= 0 || !Number.isSafeInteger(gameId)) {
-		throw new Error(`Not a match id: ${matchId}`);
-	}
-	return { platformId: matchId.slice(0, separator), gameId };
-};
 
 /**
  * Splits Riot's build string into the patch it belongs to.

--- a/backend/src/features/matches/match.controller.ts
+++ b/backend/src/features/matches/match.controller.ts
@@ -1,55 +1,22 @@
-import {
-	BadRequestException,
-	Controller,
-	Get,
-	Header,
-	Logger,
-	Param,
-	Query,
-} from "@nestjs/common";
+import { Controller, Get, Header, Logger, Param } from "@nestjs/common";
 
-import { RiotApiService } from "./../../integrations/riot/riot-api.service.ts";
 import { MatchService } from "./match.service.ts";
 
 @Controller("matches")
 export class MatchController {
 	private readonly logger = new Logger(MatchController.name);
 	private readonly matches: MatchService;
-	private readonly riot: RiotApiService;
 
-	constructor(matches: MatchService, riot: RiotApiService) {
+	constructor(matches: MatchService) {
 		this.matches = matches;
-		this.riot = riot;
-	}
-
-	/**
-	 * `GET /matches?puuid=…&start=&count=` — a page of a player's match ids,
-	 * newest first. The puuid is a filter on the collection rather than a path
-	 * segment, since the ids belong to matches, not to the player.
-	 */
-	@Get()
-	async getMatchIds(
-		@Query("puuid") puuid?: string,
-		@Query("start") start?: string,
-		@Query("count") count?: string,
-	) {
-		if (!puuid) {
-			throw new BadRequestException("A puuid query parameter is required");
-		}
-
-		const startIndex = Number(start) || 0;
-		const pageSize = Number(count) || 5;
-
-		const matchIds = await this.riot.fetchMatchIds(puuid, startIndex, pageSize);
-		this.logger.debug(
-			`Fetched ${matchIds.length} match ids (start=${startIndex}, count=${pageSize})`,
-		);
-		return matchIds;
 	}
 
 	/**
 	 * `GET /matches/:matchId` — one full match payload. The first request saves
 	 * it; every later one reads it back out of the database.
+	 *
+	 * A player's list of match ids is not here: it belongs to an account rather
+	 * than to the match collection, and is served by `GET /accounts/:puuid/matches`.
 	 *
 	 * The body is passed through as the characters Riot sent rather than
 	 * re-serialised, so the header has to be set by hand: Nest sends a string

--- a/backend/src/lib/split-match-id.test.ts
+++ b/backend/src/lib/split-match-id.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { splitMatchId } from "./split-match-id.ts";
+
+describe("splitMatchId", () => {
+	it("splits an id into its platform and game id", () => {
+		expect(splitMatchId("NA1_5607525822")).toEqual({
+			platformId: "NA1",
+			gameId: 5_607_525_822,
+		});
+	});
+
+	it("keeps the game id an exact number", () => {
+		// It is the sort key the whole index orders on, and it is past 2^32 on
+		// live shards — a lossy parse would order two adjacent games wrongly.
+		const { gameId } = splitMatchId("NA1_5607525822");
+
+		expect(Number.isSafeInteger(gameId)).toBe(true);
+		expect(String(gameId)).toBe("5607525822");
+	});
+
+	it("rejects an id with no platform", () => {
+		expect(() => splitMatchId("5607525822")).toThrow(/Not a match id/);
+		expect(() => splitMatchId("_5607525822")).toThrow(/Not a match id/);
+	});
+
+	it("rejects an id whose game component is not a number", () => {
+		expect(() => splitMatchId("NA1_")).toThrow(/Not a match id/);
+		expect(() => splitMatchId("NA1_abc")).toThrow(/Not a match id/);
+	});
+});

--- a/backend/src/lib/split-match-id.ts
+++ b/backend/src/lib/split-match-id.ts
@@ -1,0 +1,26 @@
+/**
+ * Splits a match id into the platform and game id it is built from.
+ *
+ * The id is `platform_id + "_" + game_id` in every sampled payload, so this is
+ * the authoritative source for both — more so than `info.platformId`, which the
+ * caller has no way to have asked for, and which the id index never sees at all
+ * because it holds ids whose payloads have not been fetched.
+ *
+ * The game id is a safe integer and monotonic per platform, which is what lets
+ * the index sort by recency before a single payload exists.
+ *
+ * A `matchId` in some other shape is a caller error rather than a Riot one, so
+ * this one does throw.
+ */
+export const splitMatchId = (matchId: string) => {
+	const separator = matchId.indexOf("_");
+	const raw = matchId.slice(separator + 1);
+	const gameId = Number(raw);
+	// The digit test is not redundant: `Number("")` is 0, which is a safe
+	// integer, so "NA1_" would otherwise parse as game 0 and page from a
+	// position no match occupies rather than being refused.
+	if (separator <= 0 || !/^\d+$/.test(raw) || !Number.isSafeInteger(gameId)) {
+		throw new Error(`Not a match id: ${matchId}`);
+	}
+	return { platformId: matchId.slice(0, separator), gameId };
+};

--- a/frontend/src/components/matches/match-list.tsx
+++ b/frontend/src/components/matches/match-list.tsx
@@ -1,14 +1,30 @@
 import type { IMatch } from "@/types/riot/i-match.type";
 
 import { Match, MatchSkeleton } from "./match";
+import { useMatchListSentinel } from "./use-match-list-sentinel";
 
 interface MatchListProps {
 	puuid: string;
 	matches: IMatch[];
 	loading: boolean;
+	/** A further page is on its way; the skeletons go under the games, not over them. */
+	loadingMore: boolean;
+	/** A rate-limited page is waiting to be retried; nothing is in flight. */
+	retrying: boolean;
+	hasMore: boolean;
+	onLoadMore: () => void;
 }
 
 export const MatchList = (props: MatchListProps) => {
+	// Armed only while there is a page left to fetch and none in flight, so the
+	// sentinel scrolling past during a fetch does not queue a second one. Also
+	// disarmed while a retry is pending: asking again mid-rate-limit is what
+	// keeps the limit alive.
+	const sentinelRef = useMatchListSentinel(
+		props.onLoadMore,
+		props.hasMore && !props.loadingMore && !props.retrying,
+	);
+
 	if (props.loading) {
 		return (
 			<div className="flex flex-col gap-2">
@@ -32,6 +48,36 @@ export const MatchList = (props: MatchListProps) => {
 			{props.matches.map((match) => (
 				<Match key={match.metadata.matchId} match={match} puuid={props.puuid} />
 			))}
+
+			{props.loadingMore &&
+				[0, 1, 2].map((placeholder) => <MatchSkeleton key={placeholder} />)}
+
+			{props.hasMore && (
+				// Given a real height so the observer has a rect to intersect rather
+				// than a line sitting exactly on the scroll container's edge. The
+				// button is not only a fallback: scrolling is not reachable from the
+				// keyboard, so without it older games cannot be loaded at all.
+				<div ref={sentinelRef} className="flex justify-center py-4">
+					<button
+						type="button"
+						onClick={props.onLoadMore}
+						disabled={props.loadingMore || props.retrying}
+						className="rounded-lg border border-gold/25 bg-card/40 px-4 py-2 text-muted-foreground text-xs transition-colors hover:text-foreground disabled:opacity-50"
+					>
+						{props.retrying
+							? "Rate limited — retrying shortly…"
+							: props.loadingMore
+								? "Loading…"
+								: "Load older games"}
+					</button>
+				</div>
+			)}
+
+			{!props.hasMore && (
+				<p className="py-4 text-center text-muted-foreground text-xs">
+					No older games.
+				</p>
+			)}
 		</div>
 	);
 };

--- a/frontend/src/components/matches/use-match-list-sentinel.ts
+++ b/frontend/src/components/matches/use-match-list-sentinel.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * The element that actually scrolls `node`, or null for the document.
+ *
+ * Resolved by walking up rather than passed in, because the profile has two
+ * layouts and which one is live is a breakpoint decision made in CSS: from lg up
+ * the match list scrolls inside its own column, below lg the document scrolls
+ * and no ancestor has `overflow` at all.
+ */
+const findScrollParent = (node: HTMLElement): HTMLElement | null => {
+	for (let parent = node.parentElement; parent; parent = parent.parentElement) {
+		const overflowY = getComputedStyle(parent).overflowY;
+		if (overflowY === "auto" || overflowY === "scroll") return parent;
+	}
+	return null;
+};
+
+/**
+ * Calls `onReached` when the element the returned ref is attached to scrolls
+ * into view — the trigger for loading another page of matches.
+ *
+ * The scrolling ancestor is used as the observer's root, not the viewport. This
+ * is the part that is easy to get wrong: a target is clipped by every ancestor
+ * with `overflow` *before* it is tested against the root, while `rootMargin`
+ * expands only the root's own rect. Leaving the root as the viewport therefore
+ * gives no early trigger inside a scrolling column — the margin expands a box
+ * the sentinel was already clipped out of — and leaves the trigger sitting
+ * exactly on the column's edge, where a short sentinel produces a degenerate
+ * rect. Rooting the observer on the column that scrolls makes the margin mean
+ * what it reads as.
+ *
+ * The root is resolved once, when the sentinel mounts. Crossing the lg
+ * breakpoint by resizing mid-scroll therefore leaves it stale until the next
+ * mount, which the list does on every page it loads.
+ */
+export const useMatchListSentinel = (
+	onReached: () => void,
+	enabled: boolean,
+) => {
+	/** Read inside the observer, so a new callback does not rebuild it. */
+	const callback = useRef(onReached);
+	callback.current = onReached;
+
+	const observer = useRef<IntersectionObserver | null>(null);
+
+	useEffect(() => () => observer.current?.disconnect(), []);
+
+	// A ref callback rather than a ref object: the sentinel is only rendered
+	// when there is more to load, so it mounts and unmounts, and an effect
+	// keyed on a ref object would not see either.
+	return useCallback(
+		(node: HTMLElement | null) => {
+			observer.current?.disconnect();
+			if (!node || !enabled) return;
+
+			observer.current = new IntersectionObserver(
+				(entries) => {
+					if (entries.some((entry) => entry.isIntersecting)) {
+						callback.current();
+					}
+				},
+				{ root: findScrollParent(node), rootMargin: "600px 0px" },
+			);
+			observer.current.observe(node);
+		},
+		[enabled],
+	);
+};

--- a/frontend/src/components/summoner/use-summoner.ts
+++ b/frontend/src/components/summoner/use-summoner.ts
@@ -1,12 +1,61 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { ILeagueEntry } from "@/types/riot/i-league-entry.type";
 import type { IMatch } from "@/types/riot/i-match.type";
 
 const backendUrl = import.meta.env.VITE_BACKEND_URL || "http://localhost:3080";
 
-/** How many matches the profile loads on first paint. */
-const MATCH_COUNT = 10;
+/**
+ * How many matches a page holds, on first paint and on every scroll after it.
+ *
+ * A full page is also how the hook knows more exist: the backend serves what its
+ * index holds and backfills from Riot to fill the window, so a short page means
+ * the account's history has run out rather than that the cache has.
+ */
+const MATCH_PAGE_SIZE = 10;
+
+/**
+ * How long to wait before the first retry of a rate-limited page, when the
+ * backend did not forward a `Retry-After`. Doubles per attempt from here.
+ */
+const RETRY_BASE_MS = 5_000;
+
+/**
+ * How many times a rate-limited page is retried before the list gives up.
+ *
+ * Bounded rather than endless: a tab left open on a profile would otherwise
+ * keep a rate limit alive by feeding it, and a reader who has walked away is
+ * better served by a page that stopped than one still working.
+ */
+const MAX_RETRY_ATTEMPTS = 4;
+
+/** A failed request, carrying what the retry decision needs. */
+class RequestError extends Error {
+	readonly status: number;
+	/** From the backend's forwarded `Retry-After`; null when it sent none. */
+	readonly retryAfterMs: number | null;
+
+	constructor(status: number, path: string, retryAfterMs: number | null) {
+		super(`${status} from ${path}`);
+		this.name = "RequestError";
+		this.status = status;
+		this.retryAfterMs = retryAfterMs;
+	}
+}
+
+/**
+ * How long to wait before retrying, or null if this failure is not one to
+ * retry — anything but a rate limit, or a rate limit already retried enough.
+ *
+ * Riot's own figure is preferred to the backoff whenever the backend forwarded
+ * one: it is the upstream saying when the limit actually clears, where the
+ * backoff is only a guess that avoids making things worse.
+ */
+const retryDelayMs = (error: unknown, attempt: number) => {
+	if (!(error instanceof RequestError) || error.status !== 429) return null;
+	if (attempt >= MAX_RETRY_ATTEMPTS) return null;
+	return error.retryAfterMs ?? RETRY_BASE_MS * 2 ** attempt;
+};
 
 interface IAccount {
 	puuid: string;
@@ -21,93 +70,273 @@ export interface ISummonerData {
 	matches: IMatch[];
 	loading: boolean;
 	error: string | null;
+	/** A further page is being fetched; the first page is `loading` instead. */
+	loadingMore: boolean;
+	/**
+	 * A page was rate limited and another attempt is scheduled. Distinct from
+	 * `loadingMore`: nothing is in flight, and the list must not ask again in the
+	 * meantime — asking is what keeps the limit alive.
+	 */
+	retrying: boolean;
+	/** Whether asking for another page could return anything. */
+	hasMore: boolean;
+	/** Fetches the next page. Safe to call repeatedly; only the first one runs. */
+	loadMore: () => void;
 }
+
+/**
+ * The backend forwards Riot's `Retry-After` in the error body on a 429 and
+ * nowhere else, so this only looks there. A body that is missing or not JSON is
+ * not a failure — it just means the caller backs off on its own schedule.
+ */
+const readRetryAfterMs = async (response: Response) => {
+	if (response.status !== 429) return null;
+	try {
+		const body = await response.json();
+		const seconds = Number(body?.retryAfter);
+		return Number.isFinite(seconds) && seconds >= 0 ? seconds * 1000 : null;
+	} catch {
+		return null;
+	}
+};
 
 const getJson = async (path: string) => {
 	const response = await fetch(`${backendUrl}${path}`);
 	if (!response.ok) {
-		throw new Error(`${response.status} from ${path}`);
+		throw new RequestError(
+			response.status,
+			path,
+			await readRetryAfterMs(response),
+		);
 	}
 	return response.json();
 };
 
 /**
- * Loads everything a profile page shows. The match payloads are fetched here
- * rather than inside each card so the champion stats have something to
- * aggregate — one request per match either way, but the page owns the data.
+ * What to show when the first page fails outright.
+ *
+ * A rate limit is called out rather than folded into the generic message: it is
+ * the one failure the reader can do something about, and "try again" is true of
+ * it in a way it is not of a 500.
+ */
+const describeLoadFailure = (error: unknown) => {
+	if (error instanceof RequestError && error.status === 404) {
+		return "No summoner with that riot id.";
+	}
+	if (error instanceof RequestError && error.status === 429) {
+		return "Riot is rate limiting requests right now. Try again in a minute.";
+	}
+	return "Could not load this summoner. Try again in a moment.";
+};
+
+const EMPTY: Omit<ISummonerData, "loadMore"> = {
+	account: null,
+	ranks: [],
+	matches: [],
+	loading: true,
+	error: null,
+	loadingMore: false,
+	retrying: false,
+	hasMore: false,
+};
+
+/**
+ * Loads everything a profile page shows, a page of matches at a time.
+ *
+ * The match payloads are fetched here rather than inside each card so the
+ * champion stats have something to aggregate — one request per match either
+ * way, but the page owns the data.
+ *
+ * Pages are requested by cursor, not by offset. `before=<matchId>` names a
+ * position in the history, so a game finishing while the user reads page one
+ * cannot make page two repeat two games and silently skip two others; an
+ * offset, counting from a head that moves, does exactly that.
  */
 export const useSummoner = (gameName: string, tagLine: string) => {
-	const [data, setData] = useState<ISummonerData>({
-		account: null,
-		ranks: [],
-		matches: [],
-		loading: true,
-		error: null,
-	});
+	const [data, setData] = useState<Omit<ISummonerData, "loadMore">>(EMPTY);
+
+	/**
+	 * Which profile is being loaded. Incremented on every riot id change, so a
+	 * response for a previous one is dropped rather than appended to whoever the
+	 * user has since searched for.
+	 */
+	const profileId = useRef(0);
+	/**
+	 * Guards against a second page starting before the first has finished.
+	 * A ref rather than `loadingMore`, because state has not been applied yet
+	 * when two scroll events fire in the same frame.
+	 */
+	const fetching = useRef(false);
+	/** Read by `loadMore`, which must not be rebuilt every time a page lands. */
+	const snapshot = useRef(data);
+	snapshot.current = data;
+	/** The pending retry, so switching profile or unmounting can cancel it. */
+	const retryTimer = useRef<number | null>(null);
+	/** Consecutive rate-limited attempts at the same page; reset by a success. */
+	const attempts = useRef(0);
+	/** Lets a scheduled retry call `loadMore` without depending on it. */
+	const retry = useRef(() => {});
+
+	const cancelRetry = useCallback(() => {
+		if (retryTimer.current === null) return;
+		window.clearTimeout(retryTimer.current);
+		retryTimer.current = null;
+	}, []);
+
+	/**
+	 * One page of matches: the ids for the window, then a payload per id. A full
+	 * page means there may be another; a short one is the end of the history.
+	 */
+	const fetchPage = useCallback(async (puuid: string, before?: string) => {
+		const cursor = before ? `&before=${encodeURIComponent(before)}` : "";
+		const matchIds = (await getJson(
+			`/accounts/${puuid}/matches?count=${MATCH_PAGE_SIZE}${cursor}`,
+		)) as string[];
+
+		const matches = await Promise.all(
+			matchIds.map((id) => getJson(`/matches/${id}`) as Promise<IMatch>),
+		);
+
+		return { matches, hasMore: matchIds.length === MATCH_PAGE_SIZE };
+	}, []);
 
 	useEffect(() => {
-		// Guards against a slow response for a previous riot id landing after the
-		// user has already searched for another.
-		let active = true;
+		const id = ++profileId.current;
+		fetching.current = false;
+		attempts.current = 0;
+		cancelRetry();
 
 		const load = async () => {
-			setData({
-				account: null,
-				ranks: [],
-				matches: [],
-				loading: true,
-				error: null,
-			});
+			setData(EMPTY);
 
 			try {
 				const account: IAccount = await getJson(
 					`/accounts?riotId=${encodeURIComponent(`${gameName}#${tagLine}`)}`,
 				);
-				if (!active) return;
+				if (profileId.current !== id) return;
 				setData((previous) => ({ ...previous, account }));
 
-				const [ranks, matchIds] = await Promise.all([
+				const [ranks, page] = await Promise.all([
 					getJson(`/accounts/${account.puuid}/rank`) as Promise<ILeagueEntry[]>,
-					getJson(
-						`/matches?puuid=${account.puuid}&start=0&count=${MATCH_COUNT}`,
-					) as Promise<string[]>,
+					fetchPage(account.puuid),
 				]);
-				if (!active) return;
-				setData((previous) => ({ ...previous, ranks }));
-
-				const matches = await Promise.all(
-					matchIds.map((id) => getJson(`/matches/${id}`) as Promise<IMatch>),
-				);
-				if (!active) return;
+				if (profileId.current !== id) return;
 
 				setData({
 					account,
 					ranks,
-					matches,
+					matches: page.matches,
 					loading: false,
 					error: null,
+					loadingMore: false,
+					retrying: false,
+					hasMore: page.hasMore,
 				});
 			} catch (error) {
-				if (!active) return;
+				if (profileId.current !== id) return;
 				console.error("Failed to load summoner", { gameName, tagLine, error });
 				setData({
-					account: null,
-					ranks: [],
-					matches: [],
+					...EMPTY,
 					loading: false,
-					error:
-						error instanceof Error && error.message.startsWith("404")
-							? "No summoner with that riot id."
-							: "Could not load this summoner. Try again in a moment.",
+					error: describeLoadFailure(error),
 				});
 			}
 		};
 
 		load();
 		return () => {
-			active = false;
+			// Bumping it is the cancellation: nothing in flight can match it again.
+			profileId.current += 1;
+			cancelRetry();
 		};
-	}, [gameName, tagLine]);
+	}, [gameName, tagLine, fetchPage, cancelRetry]);
 
-	return data;
+	const loadMore = useCallback(() => {
+		const current = snapshot.current;
+		const last = current.matches[current.matches.length - 1];
+		if (
+			fetching.current ||
+			current.loading ||
+			!current.hasMore ||
+			!current.account ||
+			!last
+		) {
+			return;
+		}
+
+		const id = profileId.current;
+		const puuid = current.account.puuid;
+		fetching.current = true;
+		setData((previous) => ({ ...previous, loadingMore: true }));
+
+		const run = async () => {
+			try {
+				const page = await fetchPage(puuid, last.metadata.matchId);
+				if (profileId.current !== id) return;
+
+				setData((previous) => {
+					// The cursor should make this impossible, but a repeated id would
+					// duplicate a React key, so it is filtered rather than trusted.
+					const seen = new Set(
+						previous.matches.map((match) => match.metadata.matchId),
+					);
+					return {
+						...previous,
+						matches: [
+							...previous.matches,
+							...page.matches.filter(
+								(match) => !seen.has(match.metadata.matchId),
+							),
+						],
+						loadingMore: false,
+						retrying: false,
+						hasMore: page.hasMore,
+					};
+				});
+				attempts.current = 0;
+			} catch (error) {
+				if (profileId.current !== id) return;
+
+				const delay = retryDelayMs(error, attempts.current);
+				if (delay !== null) {
+					attempts.current += 1;
+					// Held rather than abandoned: a rate limit is the upstream asking
+					// for a pause, not a refusal, so `hasMore` stays true and the page
+					// is asked for again once the pause is over.
+					setData((previous) => ({
+						...previous,
+						loadingMore: false,
+						retrying: true,
+					}));
+					retryTimer.current = window.setTimeout(() => {
+						retryTimer.current = null;
+						if (profileId.current !== id) return;
+						setData((previous) => ({ ...previous, retrying: false }));
+						retry.current();
+					}, delay);
+					return;
+				}
+
+				console.error("Failed to load more matches", { puuid, error });
+				// Stops the scroll from retrying the same failing page forever. The
+				// games already loaded stay on screen.
+				setData((previous) => ({
+					...previous,
+					loadingMore: false,
+					retrying: false,
+					hasMore: false,
+				}));
+			} finally {
+				if (profileId.current === id) fetching.current = false;
+			}
+		};
+
+		run();
+	}, [fetchPage]);
+
+	// Assigned rather than passed, so a scheduled retry reaches the current
+	// `loadMore` without the retry timer becoming one of its dependencies.
+	retry.current = loadMore;
+
+	return { ...data, loadMore };
 };

--- a/frontend/src/routes/summoner-route.tsx
+++ b/frontend/src/routes/summoner-route.tsx
@@ -20,10 +20,17 @@ import { rootRoute } from "./root-route";
 const SummonerPage = () => {
 	const { riotId } = summonerRoute.useParams();
 	const { gameName, tagLine } = parseRiotIdParam(riotId);
-	const { account, ranks, matches, loading, error } = useSummoner(
-		gameName,
-		tagLine,
-	);
+	const {
+		account,
+		ranks,
+		matches,
+		loading,
+		error,
+		loadingMore,
+		retrying,
+		hasMore,
+		loadMore,
+	} = useSummoner(gameName, tagLine);
 
 	if (error) {
 		return (
@@ -86,6 +93,10 @@ const SummonerPage = () => {
 							puuid={account?.puuid ?? ""}
 							matches={matches}
 							loading={loading}
+							loadingMore={loadingMore}
+							retrying={retrying}
+							hasMore={hasMore}
+							onLoadMore={loadMore}
 						/>
 					</div>
 				</main>


### PR DESCRIPTION
serve match id lists from a saved per-account index